### PR TITLE
チェックの非同期処理

### DIFF
--- a/web/release-checker.js
+++ b/web/release-checker.js
@@ -19,8 +19,15 @@ console.group(CONSOLE_GROUP_NAME);
         validMessage: 'Google Analyticsタグが読み込まれています',
         errorMessage: 'Google Analyticsタグが確認できません',
         check: () => {
-            var key = window.GoogleAnalyticsObject;
-            return key && !!window[key];
+            return new Promise((resolve, reject) => {
+                const key = window.GoogleAnalyticsObject;
+
+                if (key && !!window[key]) {
+                    resolve();
+                } else {
+                    reject();
+                }
+            });
         }
     }),
     new ReleaseTest({
@@ -43,9 +50,16 @@ console.group(CONSOLE_GROUP_NAME);
         name: 'Twitter Cards', 
         validMessage: 'Twitter cardsが設定されています',
         errorMessage: 'Twitter cardsがありません',
-        check: (cb) => {
-            var meta = document.querySelector('meta[property="twitter:image"]') || document.querySelector('meta[name="twitter:image"]');
-            return meta;
+        check: () => {
+            return new Promise((resolve, reject) => {
+                const meta = document.querySelector('meta[property="twitter:image"]') || document.querySelector('meta[name="twitter:image"]');
+
+                if (meta) {
+                    resolve();
+                } else {
+                    reject();
+                }
+            });
         }
     })
 ].forEach((test) => {

--- a/web/release-checker.js
+++ b/web/release-checker.js
@@ -63,34 +63,18 @@ console.group(CONSOLE_GROUP_NAME);
         }
     })
 ].forEach((test) => {
-    const check = test.check();
-
-    if (check instanceof Promise) {
-        const promise = new Promise((resolve) => {
-            check
-                .then((_res) => {
-                    resolve(test.validMessage);
-                })
-                .catch((_res) => {
-                    resolve(test.errorMessage);
-                })
-            ;
-        });
-
-        testArr.push(promise);
-    } else {
-        const result = check;
-
-        const promise = new Promise((resolve) => {
-            if (result) {
+    const promise = new Promise((resolve) => {
+        test.check()
+            .then((_res) => {
                 resolve(test.validMessage);
-            } else {
+            })
+            .catch((_res) => {
                 resolve(test.errorMessage);
-            }
-        });
+            })
+        ;
+    });
 
-        testArr.push(promise);
-    }
+    testArr.push(promise);
 });
 
 Promise.all(testArr)

--- a/web/release-checker.js
+++ b/web/release-checker.js
@@ -76,10 +76,11 @@ Promise.all(testArr)
         resArr.forEach((res) => {
             console.log(res);
         });
-        console.groupEnd(CONSOLE_GROUP_NAME);
     })
     .catch((err) => {
         console.log('エラーが発生しました:', err);
+    })
+    .then(() => {
         console.groupEnd(CONSOLE_GROUP_NAME);
-    });
+    })
 ;

--- a/web/release-checker.js
+++ b/web/release-checker.js
@@ -18,79 +18,57 @@ console.group(CONSOLE_GROUP_NAME);
         name: 'Google Analytics', 
         validMessage: 'Google Analyticsタグが読み込まれています',
         errorMessage: 'Google Analyticsタグが確認できません',
-        check: () => {
-            return new Promise((resolve, reject) => {
-                const key = window.GoogleAnalyticsObject;
+        check: new Promise((resolve, reject) => {
+            const key = window.GoogleAnalyticsObject;
 
-                if (key && !!window[key]) {
-                    resolve();
-                } else {
-                    reject();
-                }
-            });
-        }
+            if (key && !!window[key]) {
+                resolve();
+            } else {
+                reject();
+            }
+        })
     }),
     new ReleaseTest({
         name: 'OGP Image', 
         validMessage: 'OGP画像が設定されています',
         errorMessage: 'OGP画像がありません',
-        check: () => {
-            return new Promise((resolve, reject) => {
-                const meta = document.querySelector('meta[property="og:image"]');
+        check: new Promise((resolve, reject) => {
+            const meta = document.querySelector('meta[property="og:image"]');
 
-                if (meta) {
-                    resolve();
-                } else {
-                    reject();
-                }
-            });
-        }
+            if (meta) {
+                resolve();
+            } else {
+                reject();
+            }
+        })
     }),
     new ReleaseTest({
         name: 'Twitter Cards', 
         validMessage: 'Twitter cardsが設定されています',
         errorMessage: 'Twitter cardsがありません',
-        check: () => {
-            return new Promise((resolve, reject) => {
-                const meta = document.querySelector('meta[property="twitter:image"]') || document.querySelector('meta[name="twitter:image"]');
+        check: new Promise((resolve, reject) => {
+            const meta = document.querySelector('meta[property="twitter:image"]') || document.querySelector('meta[name="twitter:image"]');
 
-                if (meta) {
-                    resolve();
-                } else {
-                    reject();
-                }
-            });
-        }
+            if (meta) {
+                resolve();
+            } else {
+                reject();
+            }
+        })
     })
 ].forEach((test) => {
-    const check = test.check();
-
-    if (check instanceof Promise) {
-        const promise = new Promise((resolve) => {
-            check
-                .then((_res) => {
-                    resolve(test.validMessage);
-                })
-                .catch((_res) => {
-                    resolve(test.errorMessage);
-                })
-            ;
-        });
-
-        testArr.push(promise);
-    } else {
-        const result = check;
-
-        const promise = new Promise((resolve) => {
-            if (result) {
+    const promise = new Promise((resolve) => {
+        test.check
+            .then((_res) => {
                 resolve(test.validMessage);
-            } else {
+            })
+            .catch((_res) => {
                 resolve(test.errorMessage);
-            }
-        });
+            })
+        ;
+    });
 
-        testArr.push(promise);
-    }
+    testArr.push(promise);
 });
 
 Promise.all(testArr)

--- a/web/release-checker.js
+++ b/web/release-checker.js
@@ -1,5 +1,7 @@
 const CONSOLE_GROUP_NAME = 'release-checker';
 
+const testArr = [];
+
 class ReleaseTest {
     constructor (opts) {
         this.name = opts.name;
@@ -27,12 +29,12 @@ console.group(CONSOLE_GROUP_NAME);
         errorMessage: 'OGP画像がありません',
         check: () => {
             return new Promise((resolve, reject) => {
-                var meta = document.querySelector('meta[property="og:image"]');
+                const meta = document.querySelector('meta[property="og:image"]');
 
-                if (false) {
-                    resolve(200);
+                if (meta) {
+                    resolve();
                 } else {
-                    reject(500);
+                    reject();
                 }
             });
         }
@@ -50,23 +52,42 @@ console.group(CONSOLE_GROUP_NAME);
     const check = test.check();
 
     if (check instanceof Promise) {
-        check
-            .then((res) => {
-                console.log(res);
-            })
-            .catch((res) => {
-                console.log(res);
-            })
-        ;
-    } else {
-        const res = check;
+        const promise = new Promise((resolve) => {
+            check
+                .then((_res) => {
+                    resolve(test.validMessage);
+                })
+                .catch((_res) => {
+                    resolve(test.errorMessage);
+                })
+            ;
+        });
 
-        if (res) {
-            console.log(test.validMessage);
-        } else {
-            console.error(test.errorMessage);
-        }
+        testArr.push(promise);
+    } else {
+        const result = check;
+
+        const promise = new Promise((resolve) => {
+            if (result) {
+                resolve(test.validMessage);
+            } else {
+                resolve(test.errorMessage);
+            }
+        });
+
+        testArr.push(promise);
     }
 });
 
-console.groupEnd(CONSOLE_GROUP_NAME);
+Promise.all(testArr)
+    .then((resArr) => {
+        resArr.forEach((res) => {
+            console.log(res);
+        });
+        console.groupEnd(CONSOLE_GROUP_NAME);
+    })
+    .catch((err) => {
+        console.log('エラーが発生しました:', err);
+        console.groupEnd(CONSOLE_GROUP_NAME);
+    });
+;

--- a/web/release-checker.js
+++ b/web/release-checker.js
@@ -25,9 +25,16 @@ console.group(CONSOLE_GROUP_NAME);
         name: 'OGP Image', 
         validMessage: 'OGP画像が設定されています',
         errorMessage: 'OGP画像がありません',
-        check: (cb) => {
-            var meta = document.querySelector('meta[property="og:image"]');
-            return meta;
+        check: () => {
+            return new Promise((resolve, reject) => {
+                var meta = document.querySelector('meta[property="og:image"]');
+
+                if (false) {
+                    resolve(200);
+                } else {
+                    reject(500);
+                }
+            });
         }
     }),
     new ReleaseTest({
@@ -40,10 +47,25 @@ console.group(CONSOLE_GROUP_NAME);
         }
     })
 ].forEach((test) => {
-    if (test.check()) {
-        console.log(test.validMessage);
+    const check = test.check();
+
+    if (check instanceof Promise) {
+        check
+            .then((res) => {
+                console.log(res);
+            })
+            .catch((res) => {
+                console.log(res);
+            })
+        ;
     } else {
-        console.error(test.errorMessage);
+        const res = check;
+
+        if (res) {
+            console.log(test.validMessage);
+        } else {
+            console.error(test.errorMessage);
+        }
     }
 });
 

--- a/web/release-checker.js
+++ b/web/release-checker.js
@@ -18,57 +18,79 @@ console.group(CONSOLE_GROUP_NAME);
         name: 'Google Analytics', 
         validMessage: 'Google Analyticsタグが読み込まれています',
         errorMessage: 'Google Analyticsタグが確認できません',
-        check: new Promise((resolve, reject) => {
-            const key = window.GoogleAnalyticsObject;
+        check: () => {
+            return new Promise((resolve, reject) => {
+                const key = window.GoogleAnalyticsObject;
 
-            if (key && !!window[key]) {
-                resolve();
-            } else {
-                reject();
-            }
-        })
+                if (key && !!window[key]) {
+                    resolve();
+                } else {
+                    reject();
+                }
+            });
+        }
     }),
     new ReleaseTest({
         name: 'OGP Image', 
         validMessage: 'OGP画像が設定されています',
         errorMessage: 'OGP画像がありません',
-        check: new Promise((resolve, reject) => {
-            const meta = document.querySelector('meta[property="og:image"]');
+        check: () => {
+            return new Promise((resolve, reject) => {
+                const meta = document.querySelector('meta[property="og:image"]');
 
-            if (meta) {
-                resolve();
-            } else {
-                reject();
-            }
-        })
+                if (meta) {
+                    resolve();
+                } else {
+                    reject();
+                }
+            });
+        }
     }),
     new ReleaseTest({
         name: 'Twitter Cards', 
         validMessage: 'Twitter cardsが設定されています',
         errorMessage: 'Twitter cardsがありません',
-        check: new Promise((resolve, reject) => {
-            const meta = document.querySelector('meta[property="twitter:image"]') || document.querySelector('meta[name="twitter:image"]');
+        check: () => {
+            return new Promise((resolve, reject) => {
+                const meta = document.querySelector('meta[property="twitter:image"]') || document.querySelector('meta[name="twitter:image"]');
 
-            if (meta) {
-                resolve();
-            } else {
-                reject();
-            }
-        })
+                if (meta) {
+                    resolve();
+                } else {
+                    reject();
+                }
+            });
+        }
     })
 ].forEach((test) => {
-    const promise = new Promise((resolve) => {
-        test.check
-            .then((_res) => {
-                resolve(test.validMessage);
-            })
-            .catch((_res) => {
-                resolve(test.errorMessage);
-            })
-        ;
-    });
+    const check = test.check();
 
-    testArr.push(promise);
+    if (check instanceof Promise) {
+        const promise = new Promise((resolve) => {
+            check
+                .then((_res) => {
+                    resolve(test.validMessage);
+                })
+                .catch((_res) => {
+                    resolve(test.errorMessage);
+                })
+            ;
+        });
+
+        testArr.push(promise);
+    } else {
+        const result = check;
+
+        const promise = new Promise((resolve) => {
+            if (result) {
+                resolve(test.validMessage);
+            } else {
+                resolve(test.errorMessage);
+            }
+        });
+
+        testArr.push(promise);
+    }
 });
 
 Promise.all(testArr)


### PR DESCRIPTION
一応同期処理と非同期処理を両方ともPromiseでラップしましたが、全てのチェックをPromiseに置き換えてもいいかもしれません。
欲を言えばvalid / errorの固定文言じゃなくチェック結果に応じたメッセージの出し分けもしたい。